### PR TITLE
Apache ssl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ netbox_setup_web_frontend: false
 ```
 
 SSL/TLS configuration for the frontend web server:
-...
+```
 netbox_web_tls: false
 netbox_web_tls_port: 443
 # netbox_web_tls_crt: /etc/pki/server.crt
 # netbox_web_tls_key: /etc/pki/server.key
 # netbox_web_tls_chain:
 netbox_web_tls_redirect: false
-...
+```
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Whether or not to configure the frontend web server:
 netbox_setup_web_frontend: false
 ```
 
+SSL/TLS configuration for the frontend web server:
+...
+netbox_web_tls: false
+netbox_web_tls_port: 443
+# netbox_web_tls_crt: /etc/pki/server.crt
+# netbox_web_tls_key: /etc/pki/server.key
+# netbox_web_tls_chain:
+netbox_web_tls_redirect: false
+...
+
 ## Example Playbook
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ netbox_web_tls_port: 443
 # netbox_web_tls_crt: /etc/pki/server.crt
 # netbox_web_tls_key: /etc/pki/server.key
 # netbox_web_tls_chain:
+netbox_web_tls_redirect: false
 
 # Database related variables (password must be changed)
 netbox_database: netbox

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,11 @@ netbox_gunicorn_workers_number: "{{ ansible_processor_vcpus + 1 }}"
 
 # Web frontend variables (not configured by default)
 netbox_setup_web_frontend: false
+netbox_web_tls: false
+netbox_web_tls_port: 443
+# netbox_web_tls_crt: /etc/pki/server.crt
+# netbox_web_tls_key: /etc/pki/server.key
+# netbox_web_tls_chain:
 
 # Database related variables (password must be changed)
 netbox_database: netbox

--- a/tasks/setup_web_frontend.yml
+++ b/tasks/setup_web_frontend.yml
@@ -19,6 +19,14 @@
     - Restart Apache2
   when: netbox_web_tls
 
+- name: Enable Apache2 rewrite module (if required)
+  community.general.apache2_module:
+    state: present
+    name: rewrite
+  notify:
+    - Restart Apache2
+  when: netbox_web_tls_redirect
+
 - name: Remove default vhost
   ansible.builtin.file:
     path: "{{ netbox_apache2_sites_enabled_path }}/{{ netbox_apache2_default_vhost }}"

--- a/tasks/setup_web_frontend.yml
+++ b/tasks/setup_web_frontend.yml
@@ -11,6 +11,14 @@
   notify:
     - Restart Apache2
 
+- name: Enable Apache2 ssl module (if required)
+  community.general.apache2_module:
+    state: present
+    name: ssl
+  notify:
+    - Restart Apache2
+  when: netbox_web_tls
+
 - name: Remove default vhost
   ansible.builtin.file:
     path: "{{ netbox_apache2_sites_enabled_path }}/{{ netbox_apache2_default_vhost }}"

--- a/templates/netbox_vhost.conf.j2
+++ b/templates/netbox_vhost.conf.j2
@@ -24,4 +24,37 @@
   ProxyPass         / http://{{ netbox_gunicorn_address }}:{{ netbox_gunicorn_port }}/
   ProxyPassReverse  / http://{{ netbox_gunicorn_address }}:{{ netbox_gunicorn_port }}/
 </VirtualHost>
+
+{% if netbox_web_tls and netbox_web_tls_port %}
+
+<VirtualHost *:{{ netbox_web_tls_port }}>
+  ServerName {{ host }}
+
+  SSLEngine on
+  SSLCertificateFile {{ netbox_web_tls_crt }}
+  SSLCertificateKeyFile {{ netbox_web_tls_key }}
+  {{ (netbox_web_tls_chain is defined and netbox_web_tls_chain is not none) | ternary('', '# ') }}SSLCertificateChainFile {{ netbox_web_tls_chain | default('') }}
+
+  Alias /static {{ netbox_install_directory }}/netbox/static
+
+  # Needed to allow token-based API authentication
+  WSGIPassAuthorization on
+
+  <Directory {{ netbox_install_directory }}/netbox/static>
+    Options Indexes FollowSymLinks MultiViews
+    AllowOverride None
+    Require all granted
+  </Directory>
+
+  <Location /static>
+    ProxyPass !
+  </Location>
+
+  ProxyPreserveHost On
+  RequestHeader     set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+  ProxyPass         / http://{{ netbox_gunicorn_address }}:{{ netbox_gunicorn_port }}/
+  ProxyPassReverse  / http://{{ netbox_gunicorn_address }}:{{ netbox_gunicorn_port }}/
+</VirtualHost>
+{% endif %}
+
 {% endfor %}

--- a/templates/netbox_vhost.conf.j2
+++ b/templates/netbox_vhost.conf.j2
@@ -9,6 +9,12 @@
   # Needed to allow token-based API authentication
   WSGIPassAuthorization on
 
+{% if netbox_web_tls and netbox_web_tls_redirect %}
+  RewriteEngine On
+  RewriteCond %{HTTPS} !=on
+  RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+{% endif %}
+
   <Directory {{ netbox_install_directory }}/netbox/static>
     Options Indexes FollowSymLinks MultiViews
     AllowOverride None


### PR DESCRIPTION
as an engineer using this ansible role to deploy a netbox instance, I would like to be able to configure netbox to use SSL using variables, without having to use a separate role to manage apache, and in the same way that I am able to configure SSL in other roles that include an apache web frontend (for example zabbix)